### PR TITLE
Pigmnts Lib 0.6.0 and CLI 0.1.1

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Build
         run: cargo build --release --locked
       - run: |
+          strip target/release/${{ matrix.artifact_name }}
           mkdir ${{ matrix.asset_name }}
           cp target/release/${{ matrix.artifact_name }} ${{ matrix.asset_name }}/
           cp README.md LICENSE.md ${{ matrix.asset_name }}/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -41,7 +41,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -104,6 +104,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
+name = "bytes"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+
+[[package]]
+name = "cc"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +147,22 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "crc32fast"
@@ -232,7 +260,7 @@ checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -254,8 +282,14 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_users",
- "winapi",
+ "winapi 0.3.8",
 ]
+
+[[package]]
+name = "dtoa"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 
 [[package]]
 name = "either"
@@ -268,6 +302,99 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
+
+[[package]]
+name = "futures-io"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
+
+[[package]]
+name = "futures-task"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+
+[[package]]
+name = "futures-util"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "memchr",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -292,12 +419,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "377038bf3c89d18d6ca1431e7a5027194fbd724ca10592b9487ede5e8e144f42"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "log",
+ "slab",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "http"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "httparse"
+version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+
+[[package]]
+name = "hyper"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6081100e960d9d74734659ffc9cc91daf1c0fc7aceb8eaa94ee1a3f5046f2e"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "log",
+ "net2",
+ "pin-project",
+ "time",
+ "tokio",
+ "tower-service",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-tls",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -319,12 +540,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "inflate"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
 dependencies = [
  "adler32",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -350,6 +589,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cb931d43e71f560c81badb0191596562bafad2be06a3f9025b845c847c60df5"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
@@ -380,6 +629,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
 
 [[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,12 +656,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
 dependencies = [
  "adler32",
+]
+
+[[package]]
+name = "mio"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
+dependencies = [
+ "cfg-if",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -467,6 +798,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
+name = "openssl"
+version = "0.10.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7717097d810a0f2e2323f9e5d11e71608355e24828410b55b9d4f18aa5f9a5d8"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
 name = "pigmnts"
 version = "0.5.0"
 dependencies = [
@@ -485,9 +855,48 @@ dependencies = [
  "image",
  "pigmnts",
  "prettytable-rs",
+ "reqwest",
  "spinners",
  "termion",
 ]
+
+[[package]]
+name = "pin-project"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7804a463a8d9572f13453c516a5faea534a2403d7ced2f0c7e100eeff072772c"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.3",
+ "syn 1.0.16",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "png"
@@ -646,6 +1055,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b81e49ddec5109a9dcfc5f2a317ff53377c915e9ae9d4f2fb50914b85614e2"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_urlencoded",
+ "time",
+ "tokio",
+ "tokio-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rust-argon2"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +1117,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
 
 [[package]]
+name = "schannel"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "039c25b130bd8c1321ee2d7de7fde2659fa9c2744e4bb29711cfc852ea53cd19"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "scoped_threadpool"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +1137,29 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "572dfa3a0785509e7a44b5b4bebcf94d41ba34e9ed9eb9df722545c3b3c4144a"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb15a5fec93b7021b8a9e96009c5d8d51c15673569f7c0f6b7204e5b7b404f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -702,6 +1188,30 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "serde",
+ "url",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "smallvec"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
 
 [[package]]
 name = "spinner"
@@ -779,6 +1289,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "term"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,7 +1310,7 @@ checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
  "dirs 1.0.5",
- "winapi",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -796,7 +1320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 dependencies = [
  "dirs 2.0.2",
- "winapi",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -832,6 +1356,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+dependencies = [
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "tokio"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee5a0dd887e37d37390c13ff8ac830f992307fe30a1fff0ab8427af67211ba28"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "iovec",
+ "lazy_static",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "tokio-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+
+[[package]]
+name = "try-lock"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,10 +1466,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
+name = "url"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+dependencies = [
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
+
+[[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+
+[[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -886,6 +1535,18 @@ dependencies = [
  "quote 1.0.3",
  "syn 1.0.16",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457414a91863c0ec00090dba537f88ab955d93ca6555862c29b6d860990b8a8a"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -929,6 +1590,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
@@ -936,6 +1603,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -948,3 +1621,22 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "pigmnts-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,7 +838,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pigmnts"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pigmnts-cli"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Akash Hamirwasia"]
 edition = "2018"
 description = "Generate a color palette from an image using WebAssesmbly"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,7 @@ path = "src/main.rs"
 members = [
   "lib"
 ]
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ spinners = "1.2.0"
 termion = "1.5.5"
 prettytable-rs = "0.8.0"
 pigmnts = { path = "lib" }
+reqwest = { version = "0.10", features = ["blocking"] }
 
 [[bin]]
 name = "pigmnts"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,63 @@
 # 🎨 Pigmnts
-Pigmnts is a color palette creator from image built using Rust. It uses the [K-means++](https://en.wikipedia.org/wiki/K-means%2B%2B) clustering algorithm to select the most commonly occuring colors from the image.
+Pigmnts is a color palette creator from an image built using Rust. It uses the [K-means++](https://en.wikipedia.org/wiki/K-means%2B%2B) clustering algorithm to select the most commonly occurring colors from the image.
 
-Pigmnts library is compiled to WebAssembly which allows for super-fast color palette extraction from an image on the web.
+**Pigmnts library** is compiled to WebAssembly which allows for super-fast color palette extraction from an image on the web.
 The library can be found in the `lib` directory.
 
-## Project Structure
-The development of the Pigmnts library is in the `lib` directory.
-The root project is a Cargo workspace that uses the Pigmnts library to build a CLI.
+## Pigmnts CLI
+Pigmnts CLI is a tool designed to create color palettes from an image right on your terminal. It supports various image formats like `JPEG`, `PNG`, `GIF`, `WebP`, `TIFF` along with external HTTP(S) image URLs. It provides a beautiful terminal output to preview the colors in the palette.
+
+Pigmnts CLI comes with various output modes and provides on-demand data of the palette generated while maintaining high speeds.
+
+### Output modes
+
+#### Default mode
+The default mode displays the palette in a user-friendly way with a small preview and corresponding color codes in a tabular structure. This is meant for the common use of the CLI.
+
+![](https://user-images.githubusercontent.com/21107799/77250424-f112d600-6c6d-11ea-82ef-4ebb32d86ee0.png)
+
+### Quiet (or Silent) mode
+This mode displays only the essential output without the intermediate logs. The output is in plain text format with each data item separated by `:`. This is meant for use in a pipeline where the output of the CLI is used as input for another process. It can be activated by the `-q or --quiet` flag.
+
+![](https://user-images.githubusercontent.com/21107799/77250518-801fee00-6c6e-11ea-9086-b077447fd4d1.png)
+
+
+### Flags and options in the CLI
+The following flags and options are supported by the latest release of the CLI.
+```
+FLAGS:
+    -d, --dominance    Enable dominance percentage of colors
+    -h, --help         Prints help information
+    -x, --hex          Enable Hex code output of colors
+    -s, --hsl          Enable HSL output of colors
+    -l, --lab          Enable L*AB output of colors
+    -q, --quiet        Suppress the normal output [aliases: silent]
+    -r, --rgb          Enable RGB output of colors
+    -V, --version      Prints version information
+
+OPTIONS:
+    -c, --count <COUNT>...    Number of colors in the palette
+```
+
+#### Examples of these flags
+
+- `pigmnts pic-1.jpg -c 5 pic-2.jpg -c 8`  
+  Generate a palette of 5 colors from pic-1.jpg and 8 colors from pic-2.jpg.
+
+- `pigmnts pic-1.jpg -rxdl`  
+  Generate a palette of 5 colors from pic-1.jpg and show the RGB code, hex code, dominance, LAB code for each color in the palette.
+
+- `pigmnts pic-1.jpg pic-2.jpg -sxq`  
+  Generate a palette of 5 colors from pic-1.jpg and pic-2.jpg. For each color in the palette show the HSL code, hex code in `quiet` mode.
+
+
+## Contributing
+This repository is a Cargo workspace that includes the development of both core Pigmnts library and the CLI.
+
+### Project Structure
+- **Pigmnts Library** - development of the core library is in the `lib` directory.
+- **Pigmnts CLI** - root project is Pigmnts CLI that uses the Pigmnts library.
+
 
 ## License
 Pigmnts is [MIT Licensed](https://github.com/blenderskool/pigmnts/blob/master/LICENSE.md)

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pigmnts"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Akash Hamirwasia"]
 edition = "2018"
 description = "Generate a color palette from an image using WebAssesmbly"

--- a/lib/README.md
+++ b/lib/README.md
@@ -60,12 +60,13 @@ run();
 
 ## Functions
 Pigmnts exposes following function in WebAssembly
-#### pigments(canvas: `HtmlCanvasElement`, num_colors: `u8`, batch_size: `Option<u32>`)
+#### pigments(canvas: `HtmlCanvasElement`, k: `number`, mood: `Mood|number`, batch_size: `number`)
 
 ##### Arguments
 - `canvas` canvas element which has the image to be processed. Internally, the pixel data is taken from the canvas, and then clustered to create the color palette.  
-- `num_colors` defines the number of colors to be gathered from the image.  
-- `batch_size` (optional) defines the number of pixels to randomly sample from the image. It should be greater than the total number of pixels in the image and the `num_colors`. By default, all the pixels in the image are processed.
+- `k` defines the number of colors to be gathered from the image.  
+- `mood` defines the weight function to use. Only 'dominant' mood is supported which has a value of `0`
+- `batch_size` (optional) defines the number of pixels to randomly sample from the image. It should be greater than the total number of pixels in the image and the `k`. By default, all the pixels in the image are processed.
 
 ##### Return
 Returns an Array of Objects where each Object is a color of the following format.
@@ -93,13 +94,15 @@ Returns an Array of Objects where each Object is a color of the following format
 ```
 
 If this crate is used in some Rust projects, then following function is also available
-#### pigments_pixels(pixels: `&Vec<LAB>`, num_colors: `u8`) -> `Vec<(LAB, f32)>`
+#### pigments_pixels(pixels: `&Vec<LAB>`, k: `u8`, weight: `fn(&LAB) -> f32`, max_iter: `Option<u16>`) -> `Vec<(LAB, f32)>`
 
 This function can be used when color data is gathered from an image decoded using [image-rs](https://github.com/image-rs/image).
 
 ##### Arguments
 - `pixels` reference to a Vector of colors in `LAB` format.
-- `num_colors` defines the number of colors to be gathered from the image.
+- `k` defines the number of colors to be gathered from the image.
+- `weight` defines the weight function to use. `src/weights.rs` file has few implemented weight functions.
+- `max_iter` defines the maximum iterations that algorithm makes, default is `300`
 
 ##### Return
 Returns a vector of tuples with colors as `LAB` and dominance(as percentage) of each color found in the image.

--- a/lib/src/color.rs
+++ b/lib/src/color.rs
@@ -142,6 +142,17 @@ impl From<&HSL> for RGB {
 impl LAB {
 
     /**
+     * Helper function to create a LAB color from RGB values without creating intermediate struct
+     */
+    pub fn from_rgb(r: u8, g: u8, b: u8) -> Self {
+        Self::from(&RGB {
+            r: r,
+            g: g,
+            b: b,
+        })
+    }
+
+    /**
      * Calculates the chroma of the color 
      */
     pub fn chroma(&self) -> f32 {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -153,13 +153,7 @@ pub fn pigments(canvas: HtmlCanvasElement, k: u8, mood: Mood, batch_size: Option
     // Convert to Pixels type
     let mut pixels: Pixels = (0..data.len())
         .step_by(4)
-        .map(|i| LAB::from(
-            &RGB {
-                r: data[i],
-                g: data[i + 1],
-                b: data[i + 2]
-            }
-        ))
+        .map(|i| LAB::from_rgb(data[i], data[i+1], data[i+2]))
         .collect();
 
     // Randomly choose a sample of batch size if given

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,13 +62,7 @@ fn pigmnts(image_path: &str, count: u8) -> Result<(Vec<(LAB, f32)>, u128), Box<d
     
     let pixels: Pixels = img
         .pixels()
-        .map(|(_, _, pix)| LAB::from(
-            &RGB {
-                r: pix[0],
-                g: pix[1],
-                b: pix[2],
-            }
-        ))
+        .map(|(_, _, pix)| LAB::from_rgb(pix[0], pix[1], pix[2]))
         .collect();
     
     let weightfn = weights::resolve_mood(&weights::Mood::Dominant);

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,23 +57,22 @@ fn pigmnts(image_path: &str, count: u8) -> Result<(Vec<(LAB, f32)>, u128), Box<d
   
   img = img.resize(800, 800, image::imageops::FilterType::CatmullRom);
 
-  let mut pixels: Pixels = Vec::new();
-
   // Start a timer
   let now = Instant::now();
 
-  for (_, _, pix) in img.pixels() {
-    pixels.push(LAB::from(
+  let pixels: Pixels = img
+    .pixels()
+    .map(|(_, _, pix)| LAB::from(
       &RGB {
         r: pix[0],
         g: pix[1],
         b: pix[2],
       }
-    ));
-  }
+    ))
+    .collect();
 
   let weightfn = weights::resolve_mood(&weights::Mood::Dominant);
-  let mut output = pigments_pixels(&pixels, count, weightfn);
+  let mut output = pigments_pixels(&pixels, count, weightfn, None);
 
   // Sort the output colors based on dominance
   output.sort_by(|(_, a), (_, b)| b.partial_cmp(a).unwrap());

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn pigmnts(image_path: &str, count: u8) -> Result<(Vec<(LAB, f32)>, u128), Box<d
     img = image::open(image_path)?;
   }
   
-  img = img.resize(800, 800, image::imageops::FilterType::CatmullRom);
+  img = img.resize(512, 512, image::imageops::FilterType::CatmullRom);
 
   // Start a timer
   let now = Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,241 +21,241 @@ use pigmnts::{Pixels, color::{LAB, RGB, HSL}, weights, pigments_pixels};
 /// # Example
 /// ```
 /// let myvec = conditional_vec![
-///   is_item_1 => "Item 1",
-///   is_item_2 => "Item 2"
+///     is_item_1 => "Item 1",
+///     is_item_2 => "Item 2"
 /// ]
 /// ```
 macro_rules! conditional_vec {
-  ($( $x:expr => $y:expr),*) => {
-    {
-      let mut temp_vec = Vec::new();
-      $(
-        if $x {
-          temp_vec.push(format!("{}", $y));
+    ($( $x:expr => $y:expr),*) => {
+        {
+            let mut temp_vec = Vec::new();
+            $(
+                if $x {
+                    temp_vec.push(format!("{}", $y));
+                }
+            )*
+            temp_vec
         }
-      )*
-      temp_vec
-    }
-  };
+    };
 }
 
 /// Creates a color palette from image
 /// 
 /// Image is loaded from `image_path` and a palette of `count` colors are created
 fn pigmnts(image_path: &str, count: u8) -> Result<(Vec<(LAB, f32)>, u128), Box<dyn std::error::Error>> {
-  let mut img;
-
-  if image_path.starts_with("http://") || image_path.starts_with("https://") {
-    let mut res = reqwest::blocking::get(image_path)?;
-    let mut buf: Vec<u8> = vec![];
-    res.copy_to(&mut buf)?;
-    img = image::load_from_memory(buf.as_slice())?;
-  }
-  else {
-    img = image::open(image_path)?;
-  }
-  
-  img = img.resize(512, 512, image::imageops::FilterType::CatmullRom);
-
-  // Start a timer
-  let now = Instant::now();
-
-  let pixels: Pixels = img
-    .pixels()
-    .map(|(_, _, pix)| LAB::from(
-      &RGB {
-        r: pix[0],
-        g: pix[1],
-        b: pix[2],
-      }
-    ))
-    .collect();
-
-  let weightfn = weights::resolve_mood(&weights::Mood::Dominant);
-  let mut output = pigments_pixels(&pixels, count, weightfn, None);
-
-  // Sort the output colors based on dominance
-  output.sort_by(|(_, a), (_, b)| b.partial_cmp(a).unwrap());
-
-  return Ok((output, now.elapsed().as_millis()));
+    let mut img;
+    
+    if image_path.starts_with("http://") || image_path.starts_with("https://") {
+        let mut res = reqwest::blocking::get(image_path)?;
+        let mut buf: Vec<u8> = vec![];
+        res.copy_to(&mut buf)?;
+        img = image::load_from_memory(buf.as_slice())?;
+    }
+    else {
+        img = image::open(image_path)?;
+    }
+    
+    img = img.resize(512, 512, image::imageops::FilterType::CatmullRom);
+    
+    // Start a timer
+    let now = Instant::now();
+    
+    let pixels: Pixels = img
+        .pixels()
+        .map(|(_, _, pix)| LAB::from(
+            &RGB {
+                r: pix[0],
+                g: pix[1],
+                b: pix[2],
+            }
+        ))
+        .collect();
+    
+    let weightfn = weights::resolve_mood(&weights::Mood::Dominant);
+    let mut output = pigments_pixels(&pixels, count, weightfn, None);
+    
+    // Sort the output colors based on dominance
+    output.sort_by(|(_, a), (_, b)| b.partial_cmp(a).unwrap());
+    
+    return Ok((output, now.elapsed().as_millis()));
 }
 
 fn main() {
-
-  let matches = App::new("Pigmnts")
-                  .version(env!("CARGO_PKG_VERSION"))
-                  .author(env!("CARGO_PKG_AUTHORS"))
-                  .about("Create color palette from image")
-                  .arg(Arg::with_name("count")
-                        .short("c")
-                        .long("count")
-                        .value_name("COUNT")
-                        .help("Number of colors in the palette")
-                        .multiple(true)
-                        .number_of_values(1)
-                        .takes_value(true))
-                  .arg(Arg::with_name("input")
-                        .help("Sets the input file to use")
-                        .value_name("FILE")
-                        .required(true)
-                        .multiple(true)
-                        .index(1))
-                  .arg(Arg::with_name("quiet")
-                        .short("q")
-                        .long("quiet")
-                        .visible_alias("silent")
-                        .help("Suppress the normal output"))
-                  .arg(Arg::with_name("hex")
-                        .short("x")
-                        .long("hex")
-                        .help("Enable Hex code output of colors"))
-                  .arg(Arg::with_name("rgb")
-                        .short("r")
-                        .long("rgb")
-                        .help("Enable RGB output of colors"))
-                  .arg(Arg::with_name("hsl")
-                        .short("s")
-                        .long("hsl")
-                        .help("Enable HSL output of colors"))
-                  .arg(Arg::with_name("lab")
-                        .short("l")
-                        .long("lab")
-                        .help("Enable L*AB output of colors"))
-                  .arg(Arg::with_name("dominance")
-                        .short("d")
-                        .long("dominance")
-                        .help("Enable dominance percentage of colors"))
-                  .get_matches();
-
-  let image_paths = matches.values_of("input").unwrap();
-  let mut counts = values_t!(matches, "count", u8).unwrap_or(Vec::new());
-  let is_quiet = matches.is_present("quiet");
-  let is_rgb = matches.is_present("rgb");
-  let is_hsl = matches.is_present("hsl");
-  let is_lab = matches.is_present("lab");
-  let is_dom = matches.is_present("dominance");
-  let mut is_hex = matches.is_present("hex");
-
-  // Hex format is enabled when other formats are disabled
-  if !is_rgb && !is_hsl & !is_lab {
-    is_hex = true;
-  }
-
-  // Fill the default count value (5) for every input file if not specified
-  loop {
-    let diff: i8 = image_paths.len() as i8 - counts.len() as i8;
-    if diff > 0 {
-      counts.push(5);
-    } else {
-      break;
+    
+    let matches = App::new("Pigmnts")
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .about("Create color palette from image")
+        .arg(Arg::with_name("count")
+            .short("c")
+            .long("count")
+            .value_name("COUNT")
+            .help("Number of colors in the palette")
+            .multiple(true)
+            .number_of_values(1)
+            .takes_value(true))
+        .arg(Arg::with_name("input")
+            .help("Sets the input file to use")
+            .value_name("FILE")
+            .required(true)
+            .multiple(true)
+            .index(1))
+        .arg(Arg::with_name("quiet")
+            .short("q")
+            .long("quiet")
+            .visible_alias("silent")
+            .help("Suppress the normal output"))
+        .arg(Arg::with_name("hex")
+            .short("x")
+            .long("hex")
+            .help("Enable Hex code output of colors"))
+        .arg(Arg::with_name("rgb")
+            .short("r")
+            .long("rgb")
+            .help("Enable RGB output of colors"))
+        .arg(Arg::with_name("hsl")
+            .short("s")
+            .long("hsl")
+            .help("Enable HSL output of colors"))
+        .arg(Arg::with_name("lab")
+            .short("l")
+            .long("lab")
+            .help("Enable L*AB output of colors"))
+        .arg(Arg::with_name("dominance")
+            .short("d")
+            .long("dominance")
+            .help("Enable dominance percentage of colors"))
+        .get_matches();
+    
+    let image_paths = matches.values_of("input").unwrap();
+    let mut counts = values_t!(matches, "count", u8).unwrap_or(Vec::new());
+    let is_quiet = matches.is_present("quiet");
+    let is_rgb = matches.is_present("rgb");
+    let is_hsl = matches.is_present("hsl");
+    let is_lab = matches.is_present("lab");
+    let is_dom = matches.is_present("dominance");
+    let mut is_hex = matches.is_present("hex");
+    
+    // Hex format is enabled when other formats are disabled
+    if !is_rgb && !is_hsl & !is_lab {
+        is_hex = true;
     }
-  }
-
-  // Enumerate through each image_path and generate palettes
-  for (i, image_path) in image_paths.enumerate() {
-  
-    if is_quiet {
-      // Quiet mode only shows the result separated by ':'
-
-      let (result, _) = pigmnts(image_path, counts[i])
-                          .unwrap_or_else(|err| {
-                            eprintln!("Problem creating palette: {}", err);
-                            process::exit(1);
-                          });
-
-      for (color, dominance) in result.iter() {
-        let rgb = RGB::from(color);
-
-        let record = conditional_vec![
-          is_hex => rgb.hex(),
-          is_rgb => rgb,
-          is_hsl => HSL::from(color),
-          is_lab => color,
-          is_dom => dominance * 100.0
-        ];
-
-        println!("{}", record.join(":"));
-      }
-
-    } else {
-
-      print!("{}{}Creating a palette of ", color::Fg(color::White), style::Bold);
-      print!("{}{} ", color::Fg(color::Blue), counts[i]);
-      print!("{}colors from ", color::Fg(color::White));
-      println!("{}{}{}", color::Fg(color::Blue), image_path, style::Reset);
-
-      // Show the spinner in the terminal
-      let sp = Spinner::new(Spinners::Dots, String::default());
-      let (result, time) = pigmnts(image_path, counts[i])
-                            .unwrap_or_else(|e| {
-                              eprintln!(
-                                "{}{}Problem creating palette:{} {}",
-                                color::Fg(color::Red),
-                                style::Bold,
-                                style::Reset,
-                                e
-                              );
-                              process::exit(1);
-                            });
-
-      // Stop the spinner
-      sp.stop();
-      println!();
-
-      let mut table = Table::new();
-      table.set_format(
-        format::FormatBuilder::from(*format::consts::FORMAT_CLEAN)
-          .padding(2, 2)
-          .build()
-      );
-      let titles = conditional_vec![
-        true => "",  // Title for color preview
-        is_hex => "Hex",
-        is_rgb => "RGB",
-        is_hsl => "HSL",
-        is_lab => "LAB",
-        is_dom => "Dominance"
-      ];
-      table.set_titles(
-        Row::new(
-          titles
-            .iter()
-            .map(|x| cell!(bcFw -> x))
-            .collect()
-        )
-      );
-      
-      for (color, dominance) in result.iter() {
-        let rgb = RGB::from(color);
-        let values = conditional_vec![
-          is_hex => rgb.hex(),
-          is_rgb => rgb,
-          is_hsl => HSL::from(color),
-          is_lab => color,
-          is_dom => format!("{}%", dominance * 100.0)
-        ];
-        let mut record = row![
-          // Color preview is added
-          format!("{}  {}", color::Bg(color::Rgb(rgb.r, rgb.g, rgb.b)), style::Reset)
-        ];
-          
-        for value in values.iter() {
-          record.add_cell(cell!(value));
+    
+    // Fill the default count value (5) for every input file if not specified
+    loop {
+        let diff: i8 = image_paths.len() as i8 - counts.len() as i8;
+        if diff > 0 {
+            counts.push(5);
+        } else {
+            break;
         }
-
-        table.add_row(record);
-      }
-      table.printstd();
-      println!();
-
-      println!(
-        "{}{}✓ Success!{} Took {}ms",
-        color::Fg(color::Green),
-        style::Bold,
-        style::Reset,
-        time
-      );
     }
-  }
-
+    
+    // Enumerate through each image_path and generate palettes
+    for (i, image_path) in image_paths.enumerate() {
+        
+        if is_quiet {
+            // Quiet mode only shows the result separated by ':'
+            
+            let (result, _) = pigmnts(image_path, counts[i])
+                .unwrap_or_else(|err| {
+                    eprintln!("Problem creating palette: {}", err);
+                    process::exit(1);
+                });
+            
+            for (color, dominance) in result.iter() {
+                let rgb = RGB::from(color);
+                
+                let record = conditional_vec![
+                    is_hex => rgb.hex(),
+                    is_rgb => rgb,
+                    is_hsl => HSL::from(color),
+                    is_lab => color,
+                    is_dom => dominance * 100.0
+                ];
+                
+                println!("{}", record.join(":"));
+            }
+            
+        } else {
+            
+            print!("{}{}Creating a palette of ", color::Fg(color::White), style::Bold);
+            print!("{}{} ", color::Fg(color::Blue), counts[i]);
+            print!("{}colors from ", color::Fg(color::White));
+            println!("{}{}{}", color::Fg(color::Blue), image_path, style::Reset);
+            
+            // Show the spinner in the terminal
+            let sp = Spinner::new(Spinners::Dots, String::default());
+            let (result, time) = pigmnts(image_path, counts[i])
+                .unwrap_or_else(|e| {
+                    eprintln!(
+                        "{}{}Problem creating palette:{} {}",
+                        color::Fg(color::Red),
+                        style::Bold,
+                        style::Reset,
+                        e
+                    );
+                    process::exit(1);
+                });
+            
+            // Stop the spinner
+            sp.stop();
+            println!();
+            
+            let mut table = Table::new();
+            table.set_format(
+                format::FormatBuilder::from(*format::consts::FORMAT_CLEAN)
+                    .padding(2, 2)
+                    .build()
+            );
+            let titles = conditional_vec![
+                true => "",  // Title for color preview
+                is_hex => "Hex",
+                is_rgb => "RGB",
+                is_hsl => "HSL",
+                is_lab => "LAB",
+                is_dom => "Dominance"
+            ];
+            table.set_titles(
+                Row::new(
+                    titles
+                        .iter()
+                        .map(|x| cell!(bcFw -> x))
+                        .collect()
+                )
+            );
+            
+            for (color, dominance) in result.iter() {
+                let rgb = RGB::from(color);
+                let values = conditional_vec![
+                    is_hex => rgb.hex(),
+                    is_rgb => rgb,
+                    is_hsl => HSL::from(color),
+                    is_lab => color,
+                    is_dom => format!("{}%", dominance * 100.0)
+                ];
+                let mut record = row![
+                    // Color preview is added
+                    format!("{}  {}", color::Bg(color::Rgb(rgb.r, rgb.g, rgb.b)), style::Reset)
+                ];
+                
+                for value in values.iter() {
+                    record.add_cell(cell!(value));
+                }
+                
+                table.add_row(record);
+            }
+            table.printstd();
+            println!();
+            
+            println!(
+                "{}{}✓ Success!{} Took {}ms",
+                color::Fg(color::Green),
+                style::Bold,
+                style::Reset,
+                time
+            );
+        }
+    }
+    
 }


### PR DESCRIPTION
## Pigmnts Libary 0.6.0 :cyclone: 
The library has been updated with certain parameters for a potential speedup of the palette creation process. They include:
- Max iterations limit: Limits the number of iterations made in the clustering process. It can be set via the `max_iter` parameter in `pigments_pixels` function. Defaults to 300.
- Tolerance limit: Prevents additional iterations in the clustering step when the changes in the means are under the tolerance limit. Set to 0.0001.

Some minor additions:
- New `from_rgb` method in LAB struct to create a LAB color directly from RGB values without intermediate RGB structs.

## Pigmnts CLI 0.1.1 :globe_with_meridians: 
- Add support for external HTTP(S) image URLs.
- Limit the image dimensions to `512px` from `800px` while maintaining the aspect ratio.
- Update to Pigmnts library 0.6.0.

Fixes #18 
Fixes #15 