### PR TITLE
Data parallelism with threads 🧵

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,7 +176,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -180,7 +186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
  "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -191,8 +197,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg",
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 0.1.10",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
  "memoffset",
@@ -205,8 +211,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 dependencies = [
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 0.1.10",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -216,7 +222,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -269,7 +286,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -279,7 +296,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_users",
  "winapi 0.3.8",
@@ -309,7 +326,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -402,7 +419,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
  "wasm-bindgen",
@@ -625,7 +642,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -692,7 +709,7 @@ version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -741,7 +758,7 @@ version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.8",
 ]
@@ -810,7 +827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -846,6 +863,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 name = "pigmnts"
 version = "0.6.0"
 dependencies = [
+ "crossbeam-utils 0.8.1",
  "rand",
  "serde",
  "serde_derive",
@@ -1023,7 +1041,7 @@ checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "num_cpus",
 ]
@@ -1116,7 +1134,7 @@ dependencies = [
  "base64",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -1313,7 +1331,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand",
  "redox_syscall",
@@ -1535,7 +1553,7 @@ version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3557c397ab5a8e347d434782bcd31fc1483d927a6826804cec05cc792ee2519d"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -1562,7 +1580,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "457414a91863c0ec00090dba537f88ab955d93ca6555862c29b6d860990b8a8a"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pigmnts"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "crossbeam-utils 0.8.1",
  "rand",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "pigmnts-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pigmnts-cli"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Akash Hamirwasia"]
 edition = "2018"
 description = "Generate a color palette from an image right on the command line"
@@ -14,7 +14,7 @@ image = "0.23.2"
 spinners = "1.2.0"
 termion = "1.5.5"
 prettytable-rs = "0.8.0"
-pigmnts = { path = "lib", version = "0.6.0" }
+pigmnts = { path = "lib", version = "0.7.0" }
 reqwest = { version = "0.10", features = ["blocking"] }
 serde_cbor = "0.11.1"
 lazy_static = "^1.4.0"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,3 @@
-extern crate serde_cbor;
-extern crate serde_json;
-
 use std::fs::File;
 use std::env;
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "pigmnts"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Akash Hamirwasia"]
 edition = "2018"
-description = "Generate a color palette from an image using WebAssesmbly"
+description = "Generate a color palette from an image using K-means++"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/blenderskool/pigmnts/tree/master/lib"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 serde = "^1.0.59"
 serde_derive = "^1.0.59"
+crossbeam-utils = "0.8"
 
 [dependencies.rand]
 version = "0.7.2"

--- a/lib/src/color.rs
+++ b/lib/src/color.rs
@@ -1,4 +1,5 @@
 use std::{convert::From, fmt};
+use serde_derive::Serialize;
 
 #[derive(Serialize, Clone)]
 pub struct RGB {

--- a/lib/src/weights.rs
+++ b/lib/src/weights.rs
@@ -1,4 +1,3 @@
-extern crate wasm_bindgen;
 use crate::color;
 
 use wasm_bindgen::{prelude::*};

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ fn main() {
     let matches = App::new("Pigmnts")
         .version(env!("CARGO_PKG_VERSION"))
         .author(env!("CARGO_PKG_AUTHORS"))
-        .about("Create color palette from image")
+        .about(env!("CARGO_PKG_DESCRIPTION"))
         .arg(Arg::with_name("count")
             .short("c")
             .long("count")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,6 @@
-extern crate serde_cbor;
-
 use pigmnts::color::{LAB, RGB};
 use std::collections::HashMap;
+use lazy_static::lazy_static;
 
 /// Coverts a hex string to RGB color
 fn hex_to_rgb(s: &str) -> RGB {


### PR DESCRIPTION
## Data parallelism with threads :thread: 

Pigmnts now uses threads to achieve data parallelism in the assignment step of the K-means++ algorithm. The implementation follows the concept of MapReduce and makes use of `crossbeam` crate for scoped threads. The number of threads is set to a constant value of 5 in the library.

Coming to the interesting part of this change, threads have made pigmnts _**1.5x - 2.5x faster**_ than previous versions! :tada: 
The data from the tests can be found here https://docs.google.com/spreadsheets/d/1SJWTBTX9OjOPI9zdSc1T-hGUIiIv9osia1WB936vp8k/edit

#### Conclusions from the tests
- speedup achieved increases as the number of colors in palette "k" increases and stabilizes at higher values of k.
- In all `k > 1` cases, there is a `speedup > 1` achieved.
- While the number of threads, for now, is fixed to 5 in the library, further experiments can be done to find an optimal number of threads to achieve a good speedup.
- Memory consumption from this change hasn't been tested extensively, but some observations have shown an increase in memory consumption.

### WebAssembly?
Getting threads to get working with WebAssembly as of now is a little challenging and this experiment was majorly to test whether threads would enhance the performance in any way. Over time, these changes would be brought over to the WebAssembly library too but for now, the WebAssembly version continues to work on a single thread.

K-means and K-means++ have a lot of synchronous steps involved and parallelizing it are not very straightforward. Data parallelism here does show an improvement in the performance of the algorithm in general.

## Pigmnts Library 0.7.0 :racing_car: 
- **Crate only**: Data parallelism via threads.
- Conditional compilation to separate WebAssembly and Rust crate level code.
- Removed usage of `extern` keyword from the source.

## Pigmnts CLI 0.1.3 :racing_car: 
- Updated Pigmnts Library to 0.7.0
  - Brings improved performance from v0.7.0 of the library.
- Update `conditional_vec` macro to call closure thus evaluating RHS only when LHS is truthy.
- Update description of the CLI.
- Removed usage of `extern` keyword from the source.